### PR TITLE
Fixes #2

### DIFF
--- a/scripts/vue/formatter.js
+++ b/scripts/vue/formatter.js
@@ -9,7 +9,7 @@ const entities = new Entities();
 
 function matchTemplate(html) {
   let startReg = /<template[^>]*>/
-  let endReg = /<\/template>/
+  let endReg = /\<\/template>(?=[^<\/template>]*$)/
   html = html.split(startReg)[1]
   html = html.split(endReg)[0]
 


### PR DESCRIPTION
In order to fix nested tags you must select the last ending template tag and grab everything before it. Which is exactly what this regex does.